### PR TITLE
Add a constant with all expr-variables in order.

### DIFF
--- a/vsutil/types.py
+++ b/vsutil/types.py
@@ -5,7 +5,9 @@ __all__ = ['Dither', 'Range', 'EXPR_VARS']
 
 # this file only depends on the stdlib and should stay that way
 from enum import Enum
-from typing import Any, Callable, Optional, Type, TypeVar, Union, Literal
+
+import typing
+from typing import Any, Callable, Optional, Type, TypeVar, Union
 
 E = TypeVar('E', bound=Enum)
 
@@ -40,7 +42,7 @@ class Range(_NoSubmoduleRepr, int, Enum):
     """Full (PC) dynamic range, 0-255 in 8 bits."""
 
 
-EXPR_VARS: Literal['xyzabcdefghijklmnopqrstuvw']  = 'xyzabcdefghijklmnopqrstuvw'
+EXPR_VARS: str = 'xyzabcdefghijklmnopqrstuvw'
 """
 This constant contains a list of all variables that can appear inside an expr-string ordered
 by assignment. So the first clip will have the name EXPR_VAR_NAMES[0], the second one will

--- a/vsutil/types.py
+++ b/vsutil/types.py
@@ -6,7 +6,6 @@ __all__ = ['Dither', 'Range', 'EXPR_VARS']
 # this file only depends on the stdlib and should stay that way
 from enum import Enum
 
-import typing
 from typing import Any, Callable, Optional, Type, TypeVar, Union
 
 E = TypeVar('E', bound=Enum)

--- a/vsutil/types.py
+++ b/vsutil/types.py
@@ -5,7 +5,6 @@ __all__ = ['Dither', 'Range', 'EXPR_VARS']
 
 # this file only depends on the stdlib and should stay that way
 from enum import Enum
-
 from typing import Any, Callable, Optional, Type, TypeVar, Union
 
 E = TypeVar('E', bound=Enum)

--- a/vsutil/types.py
+++ b/vsutil/types.py
@@ -1,7 +1,7 @@
 """
 Enums and related functions.
 """
-__all__ = ['Dither', 'Range']
+__all__ = ['Dither', 'Range', 'EXPR_VAR_NAMES']
 
 # this file only depends on the stdlib and should stay that way
 from enum import Enum
@@ -38,6 +38,16 @@ class Range(_NoSubmoduleRepr, int, Enum):
     """Studio (TV) legal range, 16-235 in 8 bits."""
     FULL = 1
     """Full (PC) dynamic range, 0-255 in 8 bits."""
+
+
+EXPR_VARS: Literal['xyzabcdefghijklmnopqrstuvw']  = 'xyzabcdefghijklmnopqrstuvw'
+"""
+This constant contains a list of all variables that can appear inside an expr-string ordered
+by assignment. So the first clip will have the name EXPR_VAR_NAMES[0], the second one will
+have the name EXPR_VAR_NAMES[1], and so on.
+
+This can be used to automatically generate Expr-strings.
+"""    
 
 
 def _readable_enums(enum: Type[Enum]) -> str:

--- a/vsutil/types.py
+++ b/vsutil/types.py
@@ -1,7 +1,7 @@
 """
 Enums and related functions.
 """
-__all__ = ['Dither', 'Range', 'EXPR_VAR_NAMES']
+__all__ = ['Dither', 'Range', 'EXPR_VARS']
 
 # this file only depends on the stdlib and should stay that way
 from enum import Enum

--- a/vsutil/types.py
+++ b/vsutil/types.py
@@ -5,7 +5,7 @@ __all__ = ['Dither', 'Range', 'EXPR_VARS']
 
 # this file only depends on the stdlib and should stay that way
 from enum import Enum
-from typing import Any, Callable, Optional, Type, TypeVar, Union
+from typing import Any, Callable, Optional, Type, TypeVar, Union, Literal
 
 E = TypeVar('E', bound=Enum)
 


### PR DESCRIPTION
I have seen this constant generated in someway in multiple projects and files.

I think we should have a central place for this. Especially usually it is being done in some convoluted way that is hard to read.